### PR TITLE
[DSYS-1534] Migrate font-weight LESS variable to CSS variable

### DIFF
--- a/src/tokens_to_css.ts
+++ b/src/tokens_to_css.ts
@@ -1,7 +1,5 @@
-import { RGBA } from '@figma/rest-api-spec'
 import { Token, TokensFile } from './token_types.js'
 import { isAlias, flattenTokensFile } from './token_import.js';
-import { parseColor } from './color.js'
 import fs from 'node:fs/promises';
 
 const INPUT_DIR = 'tokens_new';


### PR DESCRIPTION
Figma cannot calculate which font to use in designs when it is given an absolute value like 400 / 500 / 600, so Figma uses [OpenType font weight identifiers](https://learn.microsoft.com/en-us/typography/opentype/spec/os2#usweightclass).

We need to process those identifiers into font-weights that are suitable for the browser, so this PR adds a feature allowing us to post-process specific token groups by name and processes the Font Weights group into numeric values.